### PR TITLE
don't to arithmetic directly on NA_INTEGER values

### DIFF
--- a/src/sparse-arithmatic.c
+++ b/src/sparse-arithmatic.c
@@ -485,12 +485,15 @@ SEXP multiplication_integers_sparse_sparse(SEXP x, SEXP y) {
       SET_INTEGER_ELT(
           out_pos, i, INTEGER_ELT(x_pos, INTEGER_ELT(x_pos_idx, i))
       );
-      SET_INTEGER_ELT(
-          out_val,
-          out_idx,
-          INTEGER_ELT(x_val, INTEGER_ELT(x_pos_idx, i)) *
-              INTEGER_ELT(y_val, INTEGER_ELT(y_pos_idx, i))
-      );
+      int cur_x_val = INTEGER_ELT(x_val, INTEGER_ELT(x_pos_idx, i));
+      int cur_y_val = INTEGER_ELT(y_val, INTEGER_ELT(y_pos_idx, i));
+
+      if (cur_x_val == NA_INTEGER || cur_y_val == NA_INTEGER) {
+        SET_INTEGER_ELT(out_val, out_idx, NA_INTEGER);
+      } else {
+        SET_INTEGER_ELT(out_val, out_idx, cur_x_val * cur_y_val);
+      }
+
       out_idx++;
     }
   }
@@ -604,7 +607,11 @@ SEXP multiplication_integers_sparse_dense(SEXP x, SEXP y) {
     if (y_val != 0) {
       SET_INTEGER_ELT(out_pos, idx, cur_pos);
       int cur_val = INTEGER_ELT(x_val, i);
-      SET_INTEGER_ELT(out_val, idx, y_val * cur_val);
+      if (y_val == NA_INTEGER || cur_val == NA_INTEGER) {
+        SET_INTEGER_ELT(out_val, idx, NA_INTEGER);
+      } else {
+        SET_INTEGER_ELT(out_val, idx, y_val * cur_val);
+      }
       idx++;
     }
   }


### PR DESCRIPTION
Reported by CRAN

https://www.stats.ox.ac.uk/pub/bdr/memtests/clang-UBSAN/sparsevctrs/tests/testthat.Rout

```text
sparse-arithmatic.c:491:57: runtime error: signed integer overflow: 3 * -2147483648 cannot be represented in type 'int'
    #0 0x7f4cd42e7e9d in multiplication_integers_sparse_sparse /data/gannet/ripley/R/packages/tests-clang-UBSAN/sparsevctrs/src/sparse-arithmatic.c:491:57
    #1 0x55a817a601b3 in R_doDotCall (/data/gannet/ripley/R/R-clang/bin/exec/R+0xf21b3)
    #2 0x55a817a9eee0 in bcEval_loop eval.c
    #3 0x55a817a9779b in bcEval eval.c
    #4 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #5 0x55a817aaf71f in R_execClosure eval.c
    #6 0x55a817aaec0b in applyClosure_core eval.c
    #7 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #8 0x55a817a5e31b in do_External (/data/gannet/ripley/R/R-clang/bin/exec/R+0xf031b)
    #9 0x55a817a9de06 in bcEval_loop eval.c
    #10 0x55a817a9779b in bcEval eval.c
    #11 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #12 0x55a817aaf71f in R_execClosure eval.c
    #13 0x55a817aaec0b in applyClosure_core eval.c
    #14 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #15 0x55a817ab3e7a in do_begin (/data/gannet/ripley/R/R-clang/bin/exec/R+0x145e7a)
    #16 0x55a817a9714f in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x12914f)
    #17 0x55a817ab60ab in do_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x1480ab)
    #18 0x55a817a9de06 in bcEval_loop eval.c
    #19 0x55a817a9779b in bcEval eval.c
    #20 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #21 0x55a817aaf71f in R_execClosure eval.c
    #22 0x55a817aaec0b in applyClosure_core eval.c
    #23 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #24 0x55a817ab6487 in do_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x148487)
    #25 0x55a817a9de06 in bcEval_loop eval.c
    #26 0x55a817a9779b in bcEval eval.c
    #27 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #28 0x55a817aaf71f in R_execClosure eval.c
    #29 0x55a817aaec0b in applyClosure_core eval.c
    #30 0x55a817ab2194 in R_forceAndCall (/data/gannet/ripley/R/R-clang/bin/exec/R+0x144194)
    #31 0x55a8179e86cb in do_lapply (/data/gannet/ripley/R/R-clang/bin/exec/R+0x7a6cb)
    #32 0x55a817af9317 in do_internal (/data/gannet/ripley/R/R-clang/bin/exec/R+0x18b317)
    #33 0x55a817aa0a7a in bcEval_loop eval.c
    #34 0x55a817a9779b in bcEval eval.c
    #35 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #36 0x55a817aaf71f in R_execClosure eval.c
    #37 0x55a817aaec0b in applyClosure_core eval.c
    #38 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #39 0x55a817ae4760 in Rf_ReplIteration (/data/gannet/ripley/R/R-clang/bin/exec/R+0x176760)
    #40 0x55a817ae60de in run_Rmainloop (/data/gannet/ripley/R/R-clang/bin/exec/R+0x1780de)
    #41 0x55a817ae614a in Rf_mainloop (/data/gannet/ripley/R/R-clang/bin/exec/R+0x17814a)
    #42 0x55a8179d5a47 in main (/data/gannet/ripley/R/R-clang/bin/exec/R+0x67a47)
    #43 0x7f4cd673c087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: c8c3fa52aaee3f5d73b6fd862e39e9d4c010b6ba)
    #44 0x7f4cd673c14a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a14a) (BuildId: c8c3fa52aaee3f5d73b6fd862e39e9d4c010b6ba)
    #45 0x55a8179d5964 in _start (/data/gannet/ripley/R/R-clang/bin/exec/R+0x67964)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior sparse-arithmatic.c:491:57 
sparse-arithmatic.c:607:43: runtime error: signed integer overflow: -2147483648 * 3 cannot be represented in type 'int'
    #0 0x7f4cd42e8589 in multiplication_integers_sparse_dense /data/gannet/ripley/R/packages/tests-clang-UBSAN/sparsevctrs/src/sparse-arithmatic.c:607:43
    #1 0x55a817a601b3 in R_doDotCall (/data/gannet/ripley/R/R-clang/bin/exec/R+0xf21b3)
    #2 0x55a817a9eee0 in bcEval_loop eval.c
    #3 0x55a817a9779b in bcEval eval.c
    #4 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #5 0x55a817aaf71f in R_execClosure eval.c
    #6 0x55a817aaec0b in applyClosure_core eval.c
    #7 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #8 0x55a817a5e31b in do_External (/data/gannet/ripley/R/R-clang/bin/exec/R+0xf031b)
    #9 0x55a817a9de06 in bcEval_loop eval.c
    #10 0x55a817a9779b in bcEval eval.c
    #11 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #12 0x55a817aaf71f in R_execClosure eval.c
    #13 0x55a817aaec0b in applyClosure_core eval.c
    #14 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #15 0x55a817ab3e7a in do_begin (/data/gannet/ripley/R/R-clang/bin/exec/R+0x145e7a)
    #16 0x55a817a9714f in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x12914f)
    #17 0x55a817ab60ab in do_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x1480ab)
    #18 0x55a817a9de06 in bcEval_loop eval.c
    #19 0x55a817a9779b in bcEval eval.c
    #20 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #21 0x55a817aaf71f in R_execClosure eval.c
    #22 0x55a817aaec0b in applyClosure_core eval.c
    #23 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #24 0x55a817ab6487 in do_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x148487)
    #25 0x55a817a9de06 in bcEval_loop eval.c
    #26 0x55a817a9779b in bcEval eval.c
    #27 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #28 0x55a817aaf71f in R_execClosure eval.c
    #29 0x55a817aaec0b in applyClosure_core eval.c
    #30 0x55a817ab2194 in R_forceAndCall (/data/gannet/ripley/R/R-clang/bin/exec/R+0x144194)
    #31 0x55a8179e86cb in do_lapply (/data/gannet/ripley/R/R-clang/bin/exec/R+0x7a6cb)
    #32 0x55a817af9317 in do_internal (/data/gannet/ripley/R/R-clang/bin/exec/R+0x18b317)
    #33 0x55a817aa0a7a in bcEval_loop eval.c
    #34 0x55a817a9779b in bcEval eval.c
    #35 0x55a817a96f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
    #36 0x55a817aaf71f in R_execClosure eval.c
    #37 0x55a817aaec0b in applyClosure_core eval.c
    #38 0x55a817a97375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
    #39 0x55a817ae4760 in Rf_ReplIteration (/data/gannet/ripley/R/R-clang/bin/exec/R+0x176760)
    #40 0x55a817ae60de in run_Rmainloop (/data/gannet/ripley/R/R-clang/bin/exec/R+0x1780de)
    #41 0x55a817ae614a in Rf_mainloop (/data/gannet/ripley/R/R-clang/bin/exec/R+0x17814a)
    #42 0x55a8179d5a47 in main (/data/gannet/ripley/R/R-clang/bin/exec/R+0x67a47)
    #43 0x7f4cd673c087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: c8c3fa52aaee3f5d73b6fd862e39e9d4c010b6ba)
    #44 0x7f4cd673c14a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a14a) (BuildId: c8c3fa52aaee3f5d73b6fd862e39e9d4c010b6ba)
    #45 0x55a8179d5964 in _start (/data/gannet/ripley/R/R-clang/bin/exec/R+0x67964)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior sparse-arithmatic.c:607:43 
```


checked with rhub https://github.com/r-hub2/lumpy-forestial-queenslandheeler-sparsevctrs/actions/runs/13904077706/job/38902761385